### PR TITLE
feat: track conversation compaction events

### DIFF
--- a/src/generate-charts.py
+++ b/src/generate-charts.py
@@ -24,6 +24,7 @@ else:
 data = storage.get_all_turns(tracking_dir)
 agent_data = storage.get_all_agents(tracking_dir)
 skill_data = storage.get_all_skills(tracking_dir)
+compaction_data = storage.get_all_compactions(tracking_dir)
 
 # Load friction data (optional — file may not exist on older installs)
 friction_file = os.path.join(tracking_dir, 'friction.json')

--- a/src/parse_compactions.py
+++ b/src/parse_compactions.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Parse compaction (compact_boundary) events from Claude Code JSONL transcripts.
+
+Usage:
+  python3 parse_compactions.py <transcript_path> <tracking_dir> <session_id> <project>
+"""
+import json
+import os
+import sys
+from datetime import date, datetime
+
+SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, SCRIPT_DIR)
+import storage
+
+
+def make_date(timestamp):
+    try:
+        return datetime.fromisoformat(
+            timestamp.replace('Z', '+00:00')).strftime('%Y-%m-%d')
+    except Exception:
+        return date.today().isoformat()
+
+
+def parse_compactions(transcript_path, session_id, project):
+    """Parse JSONL transcript for compact_boundary system events.
+    Returns list of dicts ready for storage.replace_session_compactions()."""
+    entries = []
+    with open(transcript_path, encoding='utf-8') as f:
+        for raw in f:
+            try:
+                obj = json.loads(raw)
+            except Exception:
+                continue
+
+            if obj.get('type') != 'system' or obj.get('subtype') != 'compact_boundary':
+                continue
+
+            ts = obj.get('timestamp', '')
+            meta = obj.get('compactMetadata', {})
+
+            entries.append({
+                'session_id': session_id,
+                'date': make_date(ts),
+                'project': project,
+                'timestamp': ts,
+                'trigger': meta.get('trigger', 'auto'),
+                'pre_tokens': meta.get('preTokens', 0),
+            })
+
+    return entries
+
+
+if __name__ == '__main__':
+    if len(sys.argv) != 5:
+        print(f"Usage: {sys.argv[0]} <transcript_path> <tracking_dir> <session_id> <project>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    transcript_path, tracking_dir, session_id, project = sys.argv[1:5]
+    entries = parse_compactions(transcript_path, session_id, project)
+    storage.replace_session_compactions(tracking_dir, session_id, entries)

--- a/src/stop-hook.sh
+++ b/src/stop-hook.sh
@@ -61,6 +61,10 @@ python3 "$SCRIPT_DIR/parse_friction.py" "$TRANSCRIPT" "$TRACKING_DIR/friction.js
 python3 "$SCRIPT_DIR/parse_skills.py" "$TRANSCRIPT" "$TRACKING_DIR" \
   "$SESSION_ID" "$(basename "$PROJECT_ROOT")" 2>/dev/null || true
 
+# Parse compaction events from JSONL
+python3 "$SCRIPT_DIR/parse_compactions.py" "$TRANSCRIPT" "$TRACKING_DIR" \
+  "$SESSION_ID" "$(basename "$PROJECT_ROOT")" 2>/dev/null || true
+
 # Regenerate charts
 python3 "$SCRIPT_DIR/generate-charts.py" "$TRACKING_DIR" "$TRACKING_DIR/charts.html" 2>/dev/null || true
 

--- a/src/storage.py
+++ b/src/storage.py
@@ -67,6 +67,17 @@ SKILL_DEFAULTS = {
     "error_message": None,
 }
 
+COMPACTION_COLS = [
+    "session_id", "date", "project", "timestamp",
+    "trigger", "pre_tokens",
+]
+
+COMPACTION_DEFAULTS = {
+    "timestamp": None,
+    "trigger": "auto",
+    "pre_tokens": 0,
+}
+
 SCHEMA_SQL = """\
 CREATE TABLE IF NOT EXISTS turns (
     session_id TEXT NOT NULL,
@@ -119,6 +130,17 @@ CREATE TABLE IF NOT EXISTS skills (
 CREATE INDEX IF NOT EXISTS idx_skills_session ON skills(session_id);
 CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(skill_name);
 
+CREATE TABLE IF NOT EXISTS compactions (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id TEXT NOT NULL,
+    date TEXT NOT NULL,
+    project TEXT NOT NULL,
+    timestamp TEXT,
+    trigger TEXT DEFAULT 'auto',
+    pre_tokens INTEGER DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_compactions_session ON compactions(session_id);
+
 CREATE TABLE IF NOT EXISTS metadata (
     key TEXT PRIMARY KEY,
     value TEXT
@@ -163,6 +185,17 @@ def _insert_skills(conn: sqlite3.Connection, entries: list[dict]) -> None:
     rows = []
     for e in entries:
         rows.append(tuple(e.get(col, SKILL_DEFAULTS.get(col)) for col in SKILL_COLS))
+    if rows:
+        conn.executemany(sql, rows)
+
+
+def _insert_compactions(conn: sqlite3.Connection, entries: list[dict]) -> None:
+    """INSERT compactions via executemany (always appends — autoincrement id)."""
+    placeholders = ", ".join(["?"] * len(COMPACTION_COLS))
+    sql = f"INSERT INTO compactions ({', '.join(COMPACTION_COLS)}) VALUES ({placeholders})"
+    rows = []
+    for e in entries:
+        rows.append(tuple(e.get(col, COMPACTION_DEFAULTS.get(col)) for col in COMPACTION_COLS))
     if rows:
         conn.executemany(sql, rows)
 
@@ -316,6 +349,28 @@ def get_all_skills(tracking_dir: str) -> list[dict]:
     """Return all skill rows as dicts (without the autoincrement id), ordered by id."""
     with get_db(tracking_dir) as conn:
         rows = conn.execute("SELECT * FROM skills ORDER BY id").fetchall()
+    result = []
+    for r in rows:
+        d = dict(r)
+        d.pop("id", None)
+        result.append(d)
+    return result
+
+
+def replace_session_compactions(
+    tracking_dir: str, session_id: str, entries: list[dict]
+) -> None:
+    """Delete all compactions for a session and insert replacements atomically."""
+    with get_db(tracking_dir) as conn:
+        conn.execute("DELETE FROM compactions WHERE session_id = ?", (session_id,))
+        _insert_compactions(conn, entries)
+        conn.commit()
+
+
+def get_all_compactions(tracking_dir: str) -> list[dict]:
+    """Return all compaction rows as dicts (without the autoincrement id), ordered by id."""
+    with get_db(tracking_dir) as conn:
+        rows = conn.execute("SELECT * FROM compactions ORDER BY id").fetchall()
     result = []
     for r in rows:
         d = dict(r)


### PR DESCRIPTION
## Summary
- Parse `compact_boundary` system events from JSONL transcripts into a new `compactions` SQLite table
- Captures trigger type (auto/manual) and pre-compaction token count per event
- Follows existing skills/agents pattern: schema + parser + hook integration + chart data loading

## Changes
- `src/storage.py` — `compactions` table, `COMPACTION_COLS`/`COMPACTION_DEFAULTS`, CRUD functions
- `src/parse_compactions.py` — new parser keying on `type=="system"` + `subtype=="compact_boundary"`
- `src/stop-hook.sh` — call `parse_compactions.py` after skills parsing
- `src/generate-charts.py` — load `compaction_data` for future dashboard use

## Test plan
- [ ] Verify existing tests still pass
- [ ] End a Claude Code session and confirm compactions table gets populated
- [ ] Check idempotency: re-running on same transcript doesn't duplicate entries
- [ ] Backfill historical sessions and verify data matches `grep -c compact_boundary` counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)